### PR TITLE
fix: don't force creating of new console window on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electron-injector"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 description = """
 electron-injector is an open source command-line tool written in Rust that

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![windows_subsystem = "windows"]
+
 use electron_injector::injector::Injector;
 
 fn main() {


### PR DESCRIPTION
By default, the Windows subsystem is set to `console`, which forces the creation of a new console window if the app isn't running from inside of another console. This makes the app basically not possible to use in practice, since in addition to the Electron app, there will also be a second console window created for `electron-injector`, closing which will close the Electron app as well. 

Reference:
https://rustwiki.org/en/reference/runtime.html#the-windows_subsystem-attribute